### PR TITLE
align spelling style with brackets itself

### DIFF
--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -1,6 +1,6 @@
 define({
     BEAUTIFY: 'Beautify',
-    BEAUTIFY_ON_SAVE: 'Beautify on save',
+    BEAUTIFY_ON_SAVE: 'Beautify on Save',
     UNSUPPORTED_TITLE: 'Unsupported Language',
     UNSUPPORTED_MESSAGE: 'This language is not supported.\n Supported languages are JavaScript, JSON, HTML, XML, SVG, HTML in PHP, Embedded JavaScript, Handlebars, CSS, SCSS, and LESS.'
 });


### PR DESCRIPTION
align spelling style with Brackets itself

Brackets menu uses capitalized spelling of all terms in English
